### PR TITLE
updated to git-tag to fix broken package due to moved data at libpost…

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "1.0.0" %}
+{% set version = "v1.1.alpha" %}
 
 package:
   name: libpostal
   version: "{{ version }}"
 
 source:
-  url: https://github.com/openvenues/libpostal/archive/v{{ version }}.tar.gz
-  sha256: 3035af7e15b2894069753975d953fa15a86d968103913dbf8ce4b8aa26231644
+  git_url: https://github.com/openvenues/libpostal
+  git_tag: v1.1-alpha-31-g790e24bc
 
 build:
   number: 0
@@ -26,6 +26,12 @@ requirements:
 test:
   commands:
     - test -d ${PREFIX}/share/libpostal_data
+    - test -d ${PREFIX}/share/address_expansions
+    - test -d ${PREFIX}/share/address_parser
+    - test -d ${PREFIX}/share/transliteration
+    - test -f ${PREFIX}/share/transliteration/transliteration.dat
+    - test -f ${PREFIX}/share/address_parser/address_parser_crf.dat
+    - test -f ${PREFIX}/share/address_expansions/address_dictionary.dat
     - test -f ${PREFIX}/bin/libpostal_data
     - test -f $PREFIX/lib/libpostal${SHLIB_EXT}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "v1.1.alpha" %}
+{% set version = "v1.1.0" %}
 
 package:
   name: libpostal

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,12 +26,12 @@ requirements:
 test:
   commands:
     - test -d ${PREFIX}/share/libpostal_data
-    - test -d ${PREFIX}/share/address_expansions
-    - test -d ${PREFIX}/share/address_parser
-    - test -d ${PREFIX}/share/transliteration
-    - test -f ${PREFIX}/share/transliteration/transliteration.dat
-    - test -f ${PREFIX}/share/address_parser/address_parser_crf.dat
-    - test -f ${PREFIX}/share/address_expansions/address_dictionary.dat
+    - test -d ${PREFIX}/share/libpostal_data/libpostal/address_expansions
+    - test -d ${PREFIX}/share/libpostal_data/libpostal/address_parser
+    - test -d ${PREFIX}/share/libpostal_data/libpostal/transliteration
+    - test -f ${PREFIX}/share/libpostal_data/libpostal/transliteration/transliteration.dat
+    - test -f ${PREFIX}/share/libpostal_data/libpostal/address_parser/address_parser_crf.dat
+    - test -f ${PREFIX}/share/libpostal_data/libpostal/address_expansions/address_dictionary.dat
     - test -f ${PREFIX}/bin/libpostal_data
     - test -f $PREFIX/lib/libpostal${SHLIB_EXT}
 


### PR DESCRIPTION
Updated version from latest stable to latest git master tag to make sure the package works. The current version is broken due to missing data files (moved from S3 to git) that were not packaged during build and the tests were not covering all files. Awaiting stable version at libpostal to make this nicer, but best that is possible for now.